### PR TITLE
Fix clock initialisation of FE310

### DIFF
--- a/src/hal/riscv64/FE310/Clock.cpp
+++ b/src/hal/riscv64/FE310/Clock.cpp
@@ -111,15 +111,17 @@ bool Clock::setClockFreq(uint8_t const clk_id, uint32_t const clk_freq_hz)
     if(!setPLLF(_PRCI_PLLCFG, f)) return false;
     if(!setPLLQ(_PRCI_PLLCFG, q)) return false;
 
+    /* Disable PLL bypass after configuration to activate PLL */
+    util::clrBit(_PRCI_PLLCFG, PRCI_PLLCFG_PLLBYPASS_bp);
+
     /* Wait for PLL to achieve a lock */
     while(!util::isBitSet(_PRCI_PLLCFG, PRCI_PLLCFG_PLLLOCK_bp)) { }
 
     /* plloutdiv = 1 -> hfclk = pllout / 1  */
     util::setBit(_PRCI_PLLOUTDIV, PRCI_PLLOUTDIV_PLLOUTDIVBY1_bp);
 
-    /* Disable bypass and select pllout as clock source -> hfclk = pllout */
+    /* Select pllout as clock source -> hfclk = pllout */
     util::setBit(_PRCI_PLLCFG, PRCI_PLLCFG_PLLSEL_bp);
-    util::setBit(_PRCI_PLLCFG, PRCI_PLLCFG_PLLBYPASS_bp);
 
     return true;
   }

--- a/src/hal/riscv64/FE310/util/ClockUtil.cpp
+++ b/src/hal/riscv64/FE310/util/ClockUtil.cpp
@@ -69,7 +69,7 @@ bool isValidPLLR(uint8_t const pllr)
 
 bool isValidPLLF(uint8_t const pllf)
 {
-  return ((pllf >= 2) && (pllf <= 128));
+  return ((pllf >= 2) && (pllf <= 128) && ((pllf % 2) == 0));
 }
 
 bool isValidPLLQ(uint8_t const pllq)
@@ -96,7 +96,7 @@ bool setPLLF(volatile uint32_t * PRCI_PLLCFG, uint8_t const pllf)
 {
   if(isValidPLLF(pllf))
   {
-    uint32_t const pllf_val = static_cast<uint32_t>((pllf & 0x7F) >> 1);
+    uint32_t const pllf_val = static_cast<uint32_t>(pllf & 0x7F) / 2;
     *PRCI_PLLCFG &= ~PRCI_PLLCFG_PLLF_bm;
     *PRCI_PLLCFG |= (pllf_val << 4);
     return true;


### PR DESCRIPTION
Right now you've got to comment out the following [line](https://github.com/snowfox-project/snowfox/blob/master/src/hal/riscv64/FE310/Clock.cpp#L115) in `Clock.cpp`
```diff
-while(!util::isBitSet(_PRCI_PLLCFG, PRCI_PLLCFG_PLLLOCK_bp)) { }
+//while(!util::isBitSet(_PRCI_PLLCFG, PRCI_PLLCFG_PLLLOCK_bp)) { }
```
because there is an issue with setting up the PLL. **This PR is rectifying this situation.**