### PR TITLE
Creating file RegisterBits which contains the bit definitions in enum classes

### DIFF
--- a/include/snowfox/hal/riscv64/FE310/DigitalInPin.h
+++ b/include/snowfox/hal/riscv64/FE310/DigitalInPin.h
@@ -54,7 +54,7 @@ public:
                         volatile uint32_t       * gpio_iof_en,
                         volatile uint32_t       * gpio_input_val,
                         volatile uint32_t       * gpio_pue,
-                        uint8_t           const   in_pin_number);
+                        uint32_t          const   in_pin_number);
   virtual ~DigitalInPin();
 
 
@@ -71,12 +71,12 @@ private:
 
   volatile uint32_t       * _gpio_input_val,
                           * _gpio_pue;
-           uint8_t  const   _in_pin_number;
+           uint32_t const   _in_pin_number;
 
   static void setGpioPinAsInput(volatile uint32_t       * gpio_input_en,
                                 volatile uint32_t       * gpio_output_en,
                                 volatile uint32_t       * gpio_iof_en,
-                                         uint8_t  const   in_pin_number);
+                                         uint32_t const   in_pin_number);
 
 };
 

--- a/include/snowfox/hal/riscv64/FE310/DigitalOutPin.h
+++ b/include/snowfox/hal/riscv64/FE310/DigitalOutPin.h
@@ -53,7 +53,7 @@ public:
                          volatile uint32_t       * gpio_output_en,
                          volatile uint32_t       * gpio_iof_en,
                          volatile uint32_t       * gpio_output_val,
-                                  uint8_t  const   out_pin_number);
+                                  uint32_t const   out_pin_number);
   virtual ~DigitalOutPin();
 
 
@@ -64,12 +64,12 @@ public:
 private:
 
   volatile uint32_t       * _gpio_output_val;
-          uint8_t   const   _out_pin_number;
+           uint32_t const   _out_pin_number;
 
   static void setGpioPinAsOutput(volatile uint32_t       * gpio_input_en,
                                  volatile uint32_t       * gpio_output_en,
                                  volatile uint32_t       * gpio_iof_en,
-                                 uint8_t           const   out_pin_number);
+                                 uint32_t          const   out_pin_number);
 
 };
 

--- a/include/snowfox/hal/riscv64/FE310/Io.h
+++ b/include/snowfox/hal/riscv64/FE310/Io.h
@@ -20,6 +20,12 @@
 #define INCLUDE_SNOWFOX_HAL_SIFIVE_FE310_IO_H_
 
 /**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <stdint.h>
+
+/**************************************************************************************
  * NAMESPACE
  **************************************************************************************/
 
@@ -178,6 +184,34 @@ namespace FE310
 #define PWM2_PWMCMP1     (*((volatile uint32_t *)(PWM2_BASE + 0x24)))
 #define PWM2_PWMCMP2     (*((volatile uint32_t *)(PWM2_BASE + 0x28)))
 #define PWM2_PWMCMP3     (*((volatile uint32_t *)(PWM2_BASE + 0x2C)))
+
+/**************************************************************************************
+ * TYPEDEF
+ **************************************************************************************/
+
+enum class HFXOSCCFG : uint32_t
+{
+  HFXOSCRDY = 31,
+  HFXOSCEN  = 30
+};
+
+enum class PLLCFG : uint32_t
+{
+  PLLLOCK   = 31,
+  PLLBYPASS = 18,
+  PLLREFSEL = 17,
+  PLLSEL    = 16
+};
+
+enum class PLLOUTDIV : uint32_t
+{
+  PLLOUTDIVBY1 = 8
+};
+
+enum class MSTATUS : uint32_t
+{
+  MACHINE_INTERRUPT_ENABLE = INT32_C(3)
+};
 
 /**************************************************************************************
  * NAMESPACE

--- a/include/snowfox/hal/riscv64/FE310/RegisterBits.h
+++ b/include/snowfox/hal/riscv64/FE310/RegisterBits.h
@@ -16,16 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef INCLUDE_SNOWFOX_HAL_SIFIVE_FE310_REGISTER_BITS_H_
+#define INCLUDE_SNOWFOX_HAL_SIFIVE_FE310_REGISTER_BITS_H_
+
 /**************************************************************************************
  * INCLUDE
  **************************************************************************************/
 
-#include <snowfox/hal/riscv64/FE310/Spi2Master.h>
-
-#include <snowfox/hal/riscv64/FE310/RegisterBits.h>
-
-#include <snowfox/util/BitUtil.h>
-#include <snowfox/util/EnumClassConv.hpp>
+#include <stdint.h>
 
 /**************************************************************************************
  * NAMESPACE
@@ -41,37 +39,94 @@ namespace FE310
 {
 
 /**************************************************************************************
- * CTOR/DTOR
+ * TYPEDEF
  **************************************************************************************/
 
-Spi2Master::Spi2Master(volatile uint32_t * spi2_sckmode,
-                       volatile uint32_t * spi2_fmt,
-                       volatile uint32_t * spi2_csmode,
-                       volatile uint32_t * gpio_iof_en,
-                       volatile uint32_t * gpio_iof_sel)
-: SpiMasterBase(spi2_sckmode, spi2_fmt, spi2_csmode)
+enum class PRCI_HFXOSCCFG : uint32_t
 {
-  enableGpioAccess(gpio_iof_en, gpio_iof_sel);
-}
+  HFXOSCRDY = 31,
+  HFXOSCEN  = 30
+};
 
-Spi2Master::~Spi2Master()
+enum class PRCI_PLLCFG : uint32_t
 {
+  PLLLOCK   = 31,
+  PLLBYPASS = 18,
+  PLLREFSEL = 17,
+  PLLSEL    = 16
+};
 
-}
-
-/**************************************************************************************
- * PRIVATE MEMBER FUNCTIONS
- **************************************************************************************/
-
-void Spi2Master::enableGpioAccess(volatile uint32_t * gpio_iof_en, volatile uint32_t * gpio_iof_sel)
+enum class PRCI_PLLOUTDIV : uint32_t
 {
-  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::SPI2_DQ0));
-  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::SPI2_DQ1));
-  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::SPI2_SCK));
-  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::SPI2_DQ0));
-  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::SPI2_DQ1));
-  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::SPI2_SCK));
-}
+  PLLOUTDIVBY1 = 8
+};
+
+enum class GPIO0_IOF_EN : uint32_t
+{
+  SPI1_DQ0 = 3,  /* SPI1 MOSI */
+  SPI1_DQ1 = 4,  /* SPI1 MISO */
+  SPI1_SCK = 5,  /* SPI1 SCK  */
+  UART0_RX = 16,
+  UART0_TX = 17,
+  UART1_RX = 18,
+  UART1_TX = 23,
+  SPI2_DQ0 = 27, /* SPI2 MOSI */
+  SPI2_DQ1 = 28, /* SPI2 MISO */
+  SPI2_SCK = 29, /* SPI2 SCK  */
+};
+
+enum class GPIO0_IOF_SEL : uint32_t
+{
+  SPI1_DQ0 = 3,  /* SPI1 MOSI */
+  SPI1_DQ1 = 4,  /* SPI1 MISO */
+  SPI1_SCK = 5,  /* SPI1 SCK  */
+  UART0_RX = 16,
+  UART0_TX = 17,
+  UART1_RX = 18,
+  UART1_TX = 23,
+  SPI2_DQ0 = 27, /* SPI2 MOSI */
+  SPI2_DQ1 = 28, /* SPI2 MISO */
+  SPI2_SCK = 29, /* SPI2 SCK  */
+};
+
+enum class UARTx_TXCTRL : uint32_t
+{
+  TXEN  = 0,
+  NSTOP = 1,
+};
+
+enum class UARTx_RXCTRL : uint32_t
+{
+  RXEN = 0,
+};
+
+enum class SPIx_SCKMODE : uint32_t
+{
+  POL = 1,
+  PHA = 0,
+};
+
+enum class SPIx_CSMODE : uint32_t
+{
+  MODE_1 = 1,
+  MODE_0 = 0,
+};
+
+enum class SPIx_FMT : uint32_t
+{
+  LEN_3   = 19,
+  LEN_2   = 18,
+  LEN_1   = 17,
+  LEN_0   = 16,
+  ENDIAN  = 2,
+  PROTO_1 = 1,
+  PROTO_0 = 0,
+};
+
+enum class MSTATUS : uint32_t
+{
+  MACHINE_INTERRUPT_ENABLE = INT32_C(3)
+};
 
 /**************************************************************************************
  * NAMESPACE
@@ -82,3 +137,5 @@ void Spi2Master::enableGpioAccess(volatile uint32_t * gpio_iof_en, volatile uint
 } /* hal */
 
 } /* snowfox */
+
+#endif /* INCLUDE_SNOWFOX_HAL_SIFIVE_FE310_REGISTER_BITS_H_ */

--- a/src/hal/riscv64/FE310/DigitalInPin.cpp
+++ b/src/hal/riscv64/FE310/DigitalInPin.cpp
@@ -46,7 +46,7 @@ DigitalInPin::DigitalInPin(volatile uint32_t       * gpio_input_en,
                            volatile uint32_t       * gpio_iof_en,
                            volatile uint32_t       * gpio_input_val,
                            volatile uint32_t       * gpio_pue,
-                           uint8_t           const   in_pin_number)
+                           uint32_t          const   in_pin_number)
 : _gpio_input_val(gpio_input_val),
   _gpio_pue      (gpio_pue      ),
   _in_pin_number (in_pin_number )
@@ -87,7 +87,7 @@ bool DigitalInPin::setPullUpMode(interface::PullUpMode const pullup_mode)
 void DigitalInPin::setGpioPinAsInput(volatile uint32_t       * gpio_input_en,
                                      volatile uint32_t       * gpio_output_en,
                                      volatile uint32_t       * gpio_iof_en,
-                                     uint8_t           const   in_pin_number)
+                                     uint32_t          const   in_pin_number)
 {
   util::clrBit(gpio_output_en, in_pin_number);
   util::setBit(gpio_input_en,  in_pin_number);

--- a/src/hal/riscv64/FE310/DigitalOutPin.cpp
+++ b/src/hal/riscv64/FE310/DigitalOutPin.cpp
@@ -45,7 +45,7 @@ DigitalOutPin::DigitalOutPin(volatile uint32_t       * gpio_input_en,
                              volatile uint32_t       * gpio_output_en,
                              volatile uint32_t       * gpio_iof_en,
                              volatile uint32_t       * gpio_output_val,
-                                      uint8_t  const   out_pin_number)
+                                      uint32_t const   out_pin_number)
 : _gpio_output_val(gpio_output_val),
   _out_pin_number (out_pin_number )
 {
@@ -78,7 +78,7 @@ void DigitalOutPin::clr()
 void DigitalOutPin::setGpioPinAsOutput(volatile uint32_t       * gpio_input_en,
                                        volatile uint32_t       * gpio_output_en,
                                        volatile uint32_t       * gpio_iof_en,
-                                       uint8_t           const   out_pin_number)
+                                       uint32_t          const   out_pin_number)
 {
   util::clrBit(gpio_input_en,  out_pin_number);
   util::setBit(gpio_output_en, out_pin_number);

--- a/src/hal/riscv64/FE310/Spi1Master.cpp
+++ b/src/hal/riscv64/FE310/Spi1Master.cpp
@@ -22,7 +22,10 @@
 
 #include <snowfox/hal/riscv64/FE310/Spi1Master.h>
 
+#include <snowfox/hal/riscv64/FE310/RegisterBits.h>
+
 #include <snowfox/util/BitUtil.h>
+#include <snowfox/util/EnumClassConv.hpp>
 
 /**************************************************************************************
  * NAMESPACE
@@ -36,18 +39,6 @@ namespace hal
 
 namespace FE310
 {
-
-/**************************************************************************************
- * DEFINE
- **************************************************************************************/
-
-#define GPIO_IOF_SEL_SPI1_DQ0_bp  (3) /* MOSI */
-#define GPIO_IOF_SEL_SPI1_DQ1_bp  (4) /* MISO */
-#define GPIO_IOF_SEL_SPI1_SCK_bp  (5)
-
-#define GPIO_IOF_EN_SPI1_DQ0_bp   (GPIO_IOF_SEL_SPI1_DQ0_bp)
-#define GPIO_IOF_EN_SPI1_DQ1_bp   (GPIO_IOF_SEL_SPI1_DQ1_bp)
-#define GPIO_IOF_EN_SPI1_SCK_bp   (GPIO_IOF_SEL_SPI1_SCK_bp)
 
 /**************************************************************************************
  * CTOR/DTOR
@@ -74,12 +65,12 @@ Spi1Master::~Spi1Master()
 
 void Spi1Master::enableGpioAccess(volatile uint32_t * gpio_iof_en, volatile uint32_t * gpio_iof_sel)
 {
-  util::clrBit(gpio_iof_sel, GPIO_IOF_SEL_SPI1_DQ0_bp);
-  util::clrBit(gpio_iof_sel, GPIO_IOF_SEL_SPI1_DQ1_bp);
-  util::clrBit(gpio_iof_sel, GPIO_IOF_SEL_SPI1_SCK_bp);
-  util::setBit(gpio_iof_en,  GPIO_IOF_EN_SPI1_DQ0_bp);
-  util::setBit(gpio_iof_en,  GPIO_IOF_EN_SPI1_DQ1_bp);
-  util::setBit(gpio_iof_en,  GPIO_IOF_EN_SPI1_SCK_bp);
+  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::SPI1_DQ0));
+  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::SPI1_DQ1));
+  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::SPI1_SCK));
+  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::SPI1_DQ0));
+  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::SPI1_DQ1));
+  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::SPI1_SCK));
 }
 
 /**************************************************************************************

--- a/src/hal/riscv64/FE310/UART0.cpp
+++ b/src/hal/riscv64/FE310/UART0.cpp
@@ -22,7 +22,10 @@
 
 #include <snowfox/hal/riscv64/FE310/UART0.h>
 
+#include <snowfox/hal/riscv64/FE310/RegisterBits.h>
+
 #include <snowfox/util/BitUtil.h>
+#include <snowfox/util/EnumClassConv.hpp>
 
 /**************************************************************************************
  * NAMESPACE
@@ -36,16 +39,6 @@ namespace hal
 
 namespace FE310
 {
-
-/**************************************************************************************
- * DEFINE
- **************************************************************************************/
-
-#define GPIO_IOF_SEL_UART0_RX_bp (16)
-#define GPIO_IOF_SEL_UART0_TX_bp (17)
-
-#define GPIO_IOF_EN_UART0_RX_bp  (GPIO_IOF_SEL_UART0_RX_bp)
-#define GPIO_IOF_EN_UART0_TX_bp  (GPIO_IOF_SEL_UART0_TX_bp)
 
 /**************************************************************************************
  * CTOR/DTOR
@@ -80,10 +73,10 @@ UART0::~UART0()
 
 void UART0::enableGpioAccess(volatile uint32_t * gpio_iof_en, volatile uint32_t * gpio_iof_sel)
 {
-  util::clrBit(gpio_iof_sel, GPIO_IOF_SEL_UART0_RX_bp);
-  util::clrBit(gpio_iof_sel, GPIO_IOF_SEL_UART0_TX_bp);
-  util::setBit(gpio_iof_en,  GPIO_IOF_EN_UART0_RX_bp );
-  util::setBit(gpio_iof_en,  GPIO_IOF_EN_UART0_TX_bp );
+  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::UART0_RX));
+  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::UART0_TX));
+  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::UART0_RX ));
+  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::UART0_TX ));
 }
 
 /**************************************************************************************

--- a/src/hal/riscv64/FE310/UART1.cpp
+++ b/src/hal/riscv64/FE310/UART1.cpp
@@ -22,7 +22,10 @@
 
 #include <snowfox/hal/riscv64/FE310/UART1.h>
 
+#include <snowfox/hal/riscv64/FE310/RegisterBits.h>
+
 #include <snowfox/util/BitUtil.h>
+#include <snowfox/util/EnumClassConv.hpp>
 
 /**************************************************************************************
  * NAMESPACE
@@ -36,16 +39,6 @@ namespace hal
 
 namespace FE310
 {
-
-/**************************************************************************************
- * DEFINE
- **************************************************************************************/
-
-#define GPIO_IOF_SEL_UART1_RX_bp (18)
-#define GPIO_IOF_SEL_UART1_TX_bp (23)
-
-#define GPIO_IOF_EN_UART1_RX_bp  (GPIO_IOF_SEL_UART1_RX_bp)
-#define GPIO_IOF_EN_UART1_TX_bp  (GPIO_IOF_SEL_UART1_TX_bp)
 
 /**************************************************************************************
  * CTOR/DTOR
@@ -80,10 +73,10 @@ UART1::~UART1()
 
 void UART1::enableGpioAccess(volatile uint32_t * gpio_iof_en, volatile uint32_t * gpio_iof_sel)
 {
-  util::clrBit(gpio_iof_sel, GPIO_IOF_SEL_UART1_RX_bp);
-  util::clrBit(gpio_iof_sel, GPIO_IOF_SEL_UART1_TX_bp);
-  util::setBit(gpio_iof_en,  GPIO_IOF_SEL_UART1_RX_bp);
-  util::setBit(gpio_iof_en,  GPIO_IOF_SEL_UART1_TX_bp);
+  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::UART1_RX));
+  util::clrBit(gpio_iof_sel, util::bp(GPIO0_IOF_SEL::UART1_TX));
+  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::UART1_RX ));
+  util::setBit(gpio_iof_en,  util::bp(GPIO0_IOF_EN::UART1_TX ));
 }
 
 /**************************************************************************************

--- a/src/hal/riscv64/FE310/UARTx.cpp
+++ b/src/hal/riscv64/FE310/UARTx.cpp
@@ -22,9 +22,11 @@
 
 #include <snowfox/hal/riscv64/FE310/UARTx.h>
 
-#include <snowfox/util/BitUtil.h>
-
+#include <snowfox/hal/riscv64/FE310/RegisterBits.h>
 #include <snowfox/hal/riscv64/FE310/util/UartUtil.h>
+
+#include <snowfox/util/BitUtil.h>
+#include <snowfox/util/EnumClassConv.hpp>
 
 /**************************************************************************************
  * NAMESPACE
@@ -38,17 +40,6 @@ namespace hal
 
 namespace FE310
 {
-
-/**************************************************************************************
- * DEFINE
- **************************************************************************************/
-
-/* TXCTRL */
-#define TXCTRL_TXEN_bp  (0)
-#define TXCTRL_NSTOP_bp (0)
-
-/* RXCTRL */
-#define RXCTRL_RXEN_bp  (0)
 
 /**************************************************************************************
  * CTOR/DTOR
@@ -93,17 +84,17 @@ void UARTx::receive(uint8_t & data)
 
 void UARTx::enableTx()
 {
-  util::setBit(_uartx_txctrl, TXCTRL_TXEN_bp);
+  util::setBit(_uartx_txctrl, util::bp(UARTx_TXCTRL::TXEN));
 }
 
 void UARTx::enableRx()
 {
-  util::setBit(_uartx_rxctrl, RXCTRL_RXEN_bp);
+  util::setBit(_uartx_rxctrl, util::bp(UARTx_RXCTRL::RXEN));
 }
 
 void UARTx::disableTx()
 {
-  util::clrBit(_uartx_rxctrl, RXCTRL_RXEN_bp);
+  util::clrBit(_uartx_rxctrl, util::bp(UARTx_TXCTRL::TXEN));
 }
 
 bool UARTx::setBaudRate(interface::UartBaudRate const baud_rate)
@@ -132,8 +123,8 @@ bool UARTx::setStopBit(interface::UartStopBit const stop_bit)
 {
   switch(stop_bit)
   {
-  case interface::UartStopBit::_1: util::clrBit(_uartx_txctrl, TXCTRL_NSTOP_bp); return true; break;
-  case interface::UartStopBit::_2: util::setBit(_uartx_txctrl, TXCTRL_NSTOP_bp); return true; break;
+  case interface::UartStopBit::_1: util::clrBit(_uartx_txctrl, util::bp(UARTx_TXCTRL::NSTOP)); return true; break;
+  case interface::UartStopBit::_2: util::setBit(_uartx_txctrl, util::bp(UARTx_TXCTRL::NSTOP)); return true; break;
   }
 
   return false;

--- a/src/hal/riscv64/FE310/util/InterruptUtil.cpp
+++ b/src/hal/riscv64/FE310/util/InterruptUtil.cpp
@@ -26,7 +26,10 @@
 
 #include <atomic>
 
+#include <snowfox/hal/riscv64/FE310/RegisterBits.h>
+
 #include <snowfox/util/BitUtil.h>
+#include <snowfox/util/EnumClassConv.hpp>
 
 /**************************************************************************************
  * NAMESPACE
@@ -40,13 +43,6 @@ namespace hal
 
 namespace FE310
 {
-
-/**************************************************************************************
- * DEFINE
- **************************************************************************************/
-
-#define REG_MSTATUS_MACHINE_INTERRUPT_ENABLE_bp (3)
-#define REG_MSTATUS_MACHINE_INTERRUPT_ENABLE_bm (1<<REG_MSTATUS_MACHINE_INTERRUPT_ENABLE_bp)
 
 /**************************************************************************************
  * GLOBAL VARIABLES
@@ -66,7 +62,7 @@ void enableGlobalInterrupt()
   is_global_interrupt_enabled = true;
 #else
   uint32_t mstatus;
-  asm volatile ("csrrs %0, mstatus, %1" : "=r"(mstatus) : "r"(REG_MSTATUS_MACHINE_INTERRUPT_ENABLE_bm));
+  asm volatile ("csrrs %0, mstatus, %1" : "=r"(mstatus) : "r"(util::bp(MSTATUS::MACHINE_INTERRUPT_ENABLE)));
 #endif
 }
 
@@ -76,7 +72,7 @@ void disableGlobalInterrupt()
   is_global_interrupt_enabled = false;
 #else
   uint32_t mstatus;
-  asm volatile ("csrrc %0, mstatus, %1" : "=r"(mstatus) : "r"(REG_MSTATUS_MACHINE_INTERRUPT_ENABLE_bm));
+  asm volatile ("csrrc %0, mstatus, %1" : "=r"(mstatus) : "r"(util::bp(MSTATUS::MACHINE_INTERRUPT_ENABLE)));
 #endif
 }
 
@@ -87,7 +83,7 @@ bool isGlobalInterruptEnabled()
 #else
   uint32_t mstatus;
   asm volatile("csrr %0, mstatus" : "=r" (mstatus));
-  return util::isBitSet(mstatus, REG_MSTATUS_MACHINE_INTERRUPT_ENABLE_bp);
+  return util::isBitSet(mstatus, util::bp(MSTATUS::MACHINE_INTERRUPT_ENABLE));
 #endif
 }
 


### PR DESCRIPTION
This PR replaces the usage of defines for register bit positions with enum classes which provide a typesafe (and therefore compiler-verifable) way to provide the position of bits within SFRs.