### PR TITLE
Install AVR-GCC from pre-built binaries instead of via sudo apt-get install

### DIFF
--- a/.ci/script/run-install-toolchain-avr.sh
+++ b/.ci/script/run-install-toolchain-avr.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 sudo apt-get update
-sudo apt-get install cmake avr-libc binutils-avr gcc-avr avrdude
-avr-gcc --version
-avr-g++ --version
+sudo apt-get install cmake
+cd /opt
+sudo wget https://github.com/snowfox-project/snowfox-avr-gcc/releases/download/9.2.0/avr-gcc-9.2.0-x64-linux.tar.gz
+sudo tar -xzvf avr-gcc-9.2.0-x64-linux.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -179,6 +179,7 @@ matrix:
 
 install:
   - .ci/script/run-install-toolchain-avr.sh
+  - export PATH="$PATH:/opt/avr/bin"
   - .ci/script/run-install-toolchain-riscv64.sh
   - export PATH="$PATH:${TRAVIS_BUILD_DIR}/toolchain/riscv64-unknown-elf-gcc-8.2.0-2019.02.0-x86_64-linux-ubuntu14/bin"
 script: true


### PR DESCRIPTION
This fixes #22 .