### PR TITLE
Adding version struct 

### DIFF
--- a/include/snowfox/Version.h
+++ b/include/snowfox/Version.h
@@ -1,0 +1,46 @@
+/**
+ * Snowfox is a modular RTOS with extensive IO support.
+ * Copyright (C) 2017 - 2020 Alexander Entinger / LXRobotics GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef INCLUDE_SNOWFOX_VERSION_H_
+#define INCLUDE_SNOWFOX_VERSION_H_
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+namespace snowfox
+{
+
+/**************************************************************************************
+ * CLASS DECLARATION
+ **************************************************************************************/
+
+struct Version
+{
+  static constexpr uint32_t Major = 0;
+  static constexpr uint32_t Minor = 0;
+  static constexpr uint32_t Patch = 1;
+};
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+} /* snowfox */
+
+#endif /* INCLUDE_SNOWFOX_VERSION_H_ */


### PR DESCRIPTION
to be able to access the current snowfox versio…n and verify with e.g. static_assert.
```C++
#include <snowfox/Version.h>
/* ... */
static_assert(snowfox::Version::Major >= 2, "This application requires at least Snowfox 2.x.x");
```