### PR TITLE
Directly reading of SREG register leads to faster locking/unlocking

### DIFF
--- a/include/snowfox/hal/avr/common/ATxxxx/CriticalSection.h
+++ b/include/snowfox/hal/avr/common/ATxxxx/CriticalSection.h
@@ -43,8 +43,7 @@ class CriticalSection : public interface::CriticalSection
 
 public:
 
-           CriticalSection(volatile uint8_t * sreg);
-  virtual ~CriticalSection();
+  virtual ~CriticalSection() { }
 
 
   virtual void lock  () override;
@@ -53,8 +52,7 @@ public:
 
 private:
 
-  volatile uint8_t * _sreg;
-           uint8_t   _sreg_iflag;
+  static volatile uint8_t _sreg_save;
 
 };
 


### PR DESCRIPTION
Assembly code of 'lock'/'unlock' **before** change:
```C++
void CriticalSection::lock()
{
     906:	e8 2f       	mov	r30, r24
     908:	f9 2f       	mov	r31, r25
  _sreg_iflag = *_sreg & GI_bm;
     90a:	a2 81       	ldd	r26, Z+2	; 0x02
     90c:	b3 81       	ldd	r27, Z+3	; 0x03
     90e:	8c 91       	ld	r24, X
     910:	80 78       	andi	r24, 0x80	; 128
     912:	84 83       	std	Z+4, r24	; 0x04
#if MCU_ARCH_avr
  asm volatile("cli");
     914:	f8 94       	cli
#else
  *_sreg &= ~GI_bm; /* Has the same effect as 'cli' */
#endif
}
     916:	08 95       	ret

00000918 <_ZN7snowfox3hal6ATxxxx15CriticalSection6unlockEv>:

void CriticalSection::unlock()
{
     918:	e8 2f       	mov	r30, r24
     91a:	f9 2f       	mov	r31, r25
  *_sreg |= _sreg_iflag;
     91c:	a2 81       	ldd	r26, Z+2	; 0x02
     91e:	b3 81       	ldd	r27, Z+3	; 0x03
     920:	8c 91       	ld	r24, X
     922:	94 81       	ldd	r25, Z+4	; 0x04
     924:	89 2b       	or	r24, r25
     926:	8c 93       	st	X, r24
}
     928:	08 95       	ret
```

Assembly code of 'lock'/'unlock' **after** change:
```C++
void CriticalSection::lock()
{
#if MCU_ARCH_avr
  _sreg_save = SREG;
     904:	8f b7       	in	r24, 0x3f	; 63
     906:	80 93 02 02 	sts	0x0202, r24	; 0x800202 <_ZN7snowfox3hal6ATxxxx15CriticalSection10_sreg_saveE>
  __asm__ volatile ("" ::: "memory");
  cli();
     90a:	f8 94       	cli
#endif
}
     90c:	08 95       	ret

0000090e <_ZN7snowfox3hal6ATxxxx15CriticalSection6unlockEv>:

void CriticalSection::unlock()
{
#if MCU_ARCH_avr
  SREG = _sreg_save;
     90e:	80 91 02 02 	lds	r24, 0x0202	; 0x800202 <_ZN7snowfox3hal6ATxxxx15CriticalSection10_sreg_saveE>
     912:	8f bf       	out	0x3f, r24	; 63
  __asm__ volatile ("" ::: "memory");
#endif
}
     914:	08 95       	ret
```